### PR TITLE
feat: Initial NeRF implementation with training capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+torch
+torchvision
+numpy
+matplotlib
+imageio
+configargparse
+tqdm
+tensorboard

--- a/scripts/train_nerf.py
+++ b/scripts/train_nerf.py
@@ -1,0 +1,333 @@
+import os
+import time
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import numpy as np
+import configargparse
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+import imageio
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+
+# Adjust imports based on actual project structure
+# Assuming src is in PYTHONPATH or script is run from root with python -m scripts.train_nerf
+from src.datasets.blender import BlenderDataset
+from src.models.nerf import PositionalEncoder, NeRF, render_rays, sample_pdf
+
+def parse_args():
+    parser = configargparse.ArgumentParser()
+    parser.add_argument('--config', is_config_file=True, help='Path to config file.')
+    parser.add_argument('--expname', type=str, required=True, help='Experiment name.')
+    parser.add_argument('--basedir', type=str, default='./logs/', help='Base directory for logging and checkpoints.')
+
+    # Dataset options
+    parser.add_argument('--dataset_path', type=str, required=True, help='Path to the Blender dataset.')
+    # Note: --white_bkgd is for rendering, --data_white_bkgd is for dataset loading
+    parser.add_argument('--white_bkgd', action='store_true', help='For rendering, if set, composite output onto a white background.')
+    parser.add_argument('--data_white_bkgd', action='store_true', help='For dataset loading, if set, blend RGBA images onto a white background. Default is black.')
+
+    # Training options
+    parser.add_argument('--num_epochs', type=int, default=100, help='Number of training epochs.')
+    parser.add_argument('--batch_size', type=int, default=1024, help='Number of rays per batch.')
+    parser.add_argument('--lr', type=float, default=5e-4, help='Learning rate.')
+    parser.add_argument('--seed', type=int, default=42, help='Random seed.')
+    parser.add_argument('--lr_decay_factor', type=float, default=0.1, help='Factor by which to decay learning rate.')
+    parser.add_argument('--lr_decay_steps', type=int, default=250000, help='Number of steps over which to decay learning rate (or epochs if using StepLR with epochs).') # Adjusted help
+    parser.add_argument('--num_workers', type=int, default=4, help='Number of DataLoader workers.')
+
+    # NeRF model options
+    parser.add_argument('--net_depth', type=int, default=8, help='Depth of the main NeRF MLP (D).')
+    parser.add_argument('--net_width', type=int, default=256, help='Width of the main NeRF MLP (W).')
+    parser.add_argument('--input_ch_pts_L', type=int, default=10, help='Number of frequencies for points positional encoding (L_pts).')
+    parser.add_argument('--input_ch_views_L', type=int, default=4, help='Number of frequencies for view directions positional encoding (L_views).')
+    parser.add_argument('--use_viewdirs', action='store_true', help='Whether to use view directions.')
+
+    # Rendering options
+    parser.add_argument('--N_samples_coarse', type=int, default=64, help='Number of coarse samples per ray.')
+    parser.add_argument('--N_samples_fine', type=int, default=128, help='Number of fine samples per ray (for hierarchical sampling).')
+    parser.add_argument('--use_hierarchical', action='store_true', help='Whether to use hierarchical sampling.')
+    parser.add_argument('--lindisp', action='store_true', help='Sample linearly in disparity rather than depth.')
+    parser.add_argument('--near', type=float, default=2.0, help='Near bound for ray sampling.')
+    parser.add_argument('--far', type=float, default=6.0, help='Far bound for ray sampling.')
+
+    # Logging/checkpointing options
+    parser.add_argument('--log_freq', type=int, default=100, help='Logging frequency in iterations.')
+    parser.add_argument('--save_freq', type=int, default=10, help='Checkpoint saving frequency in epochs.')
+    parser.add_argument('--val_img_freq', type=int, default=500, help='Validation image rendering frequency in iterations.')
+    parser.add_argument('--resume_from_checkpoint', type=str, default=None, help='Path to checkpoint file to resume training from (e.g., "latest.pth" or a specific checkpoint file).')
+
+    args = parser.parse_args()
+    return args
+
+def train():
+    args = parse_args()
+
+    # Set random seed
+    if args.seed is not None:
+        print(f"Setting random seed to {args.seed}")
+        torch.manual_seed(args.seed)
+        np.random.seed(args.seed)
+
+    # Create experiment directory
+    exp_dir = os.path.join(args.basedir, args.expname)
+    os.makedirs(exp_dir, exist_ok=True)
+
+    print(f"Experiment directory created at: {exp_dir}")
+
+    # Device Setup
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    # Dataset and DataLoader
+    train_dataset = BlenderDataset(dataset_path=args.dataset_path, split='train', data_white_bkgd=args.data_white_bkgd)
+    # pin_memory=True can speed up CPU to GPU data transfer if CUDA is available
+    train_loader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers, pin_memory=torch.cuda.is_available())
+
+    val_dataset = BlenderDataset(dataset_path=args.dataset_path, split='val', data_white_bkgd=args.data_white_bkgd)
+    # For validation, batch_size is 1 (one image at a time), no shuffle, fewer workers often fine.
+    val_loader = DataLoader(val_dataset, batch_size=1, shuffle=False, num_workers=0)
+
+    # Assuming H, W, focal are attributes of the dataset object after initialization
+    H, W, focal = train_dataset.height, train_dataset.width, train_dataset.focal
+    print(f"Dataset info: H={H}, W={W}, focal={focal}. Near plane: {args.near}, Far plane: {args.far}")
+    print(f"Loaded {len(train_dataset)} training images (approx {len(train_dataset) * H * W // args.batch_size} batches), "
+          f"{len(val_dataset)} validation images.")
+
+    # Positional Encoders
+    embed_fn_pts = PositionalEncoder(input_dims=3, num_freqs=args.input_ch_pts_L, log_sampling=True).to(device)
+    input_ch_pts = embed_fn_pts.output_dims
+
+    embed_fn_views = None
+    input_ch_views = 0
+    if args.use_viewdirs:
+        embed_fn_views = PositionalEncoder(input_dims=3, num_freqs=args.input_ch_views_L, log_sampling=True).to(device)
+        input_ch_views = embed_fn_views.output_dims
+    print(f"Positional encoding: pts_L={args.input_ch_pts_L} (->{input_ch_pts} dims), "
+          f"views_L={args.input_ch_views_L if args.use_viewdirs else 'N/A'} (->{input_ch_views} dims if used)")
+
+    # NeRF Models
+    # Skip connection index: if D=8, net_depth//2 = 4. Layer self.pts_linears[4] is the one after which concat happens.
+    # This means layer self.pts_linears[5] will be Linear(W + input_ch_pts, W)
+    skip_layer_index = args.net_depth // 2
+    model_coarse = NeRF(D=args.net_depth, W=args.net_width,
+                          input_ch_pts=input_ch_pts,
+                          input_ch_views=input_ch_views,
+                          skips=[skip_layer_index],
+                          use_viewdirs=args.use_viewdirs).to(device)
+    print(f"Coarse NeRF model initialized: D={args.net_depth}, W={args.net_width}, skips at layer {skip_layer_index}.")
+
+    model_fine = None
+    if args.use_hierarchical:
+        model_fine = NeRF(D=args.net_depth, W=args.net_width,
+                            input_ch_pts=input_ch_pts,
+                            input_ch_views=input_ch_views,
+                            skips=[skip_layer_index],
+                            use_viewdirs=args.use_viewdirs).to(device)
+        print(f"Fine NeRF model initialized: D={args.net_depth}, W={args.net_width}, skips at layer {skip_layer_index}.")
+
+    # Optimizer
+    params_to_optimize = list(model_coarse.parameters())
+    if model_fine:
+        params_to_optimize.extend(list(model_fine.parameters()))
+    optimizer = optim.Adam(params_to_optimize, lr=args.lr)
+    print(f"Optimizer initialized (Adam) with learning rate: {args.lr}.")
+
+    # (Placeholder) Initialize learning rate scheduler
+    # Example: Exponential decay based on global_step
+    # def lr_lambda(step):
+    #    return args.lr_decay_factor**(step / args.lr_decay_steps)
+    # scheduler = optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lr_lambda)
+    # Or, a StepLR scheduler based on epochs:
+    # scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=args.lr_decay_steps, gamma=args.lr_decay_factor) # If lr_decay_steps is in epochs
+    print("Placeholder: Learning rate scheduler (e.g. LambdaLR for per-step decay or StepLR for per-epoch decay).")
+
+    # Training State Variables
+    start_epoch = 0
+    global_step = 0
+
+    # Checkpoint Loading
+    if args.resume_from_checkpoint:
+        checkpoint_path_arg = args.resume_from_checkpoint
+        resolved_path = None
+
+        if os.path.exists(checkpoint_path_arg):
+            resolved_path = checkpoint_path_arg
+        else:
+            alt_path = os.path.join(args.basedir, args.expname, 'checkpoints', checkpoint_path_arg)
+            if os.path.exists(alt_path):
+                resolved_path = alt_path
+
+        if resolved_path:
+            print(f"Resuming training from checkpoint: {resolved_path}")
+            try:
+                checkpoint = torch.load(resolved_path, map_location=device)
+
+                model_coarse.load_state_dict(checkpoint['model_coarse_state_dict'])
+                if model_fine is not None and 'model_fine_state_dict' in checkpoint:
+                    model_fine.load_state_dict(checkpoint['model_fine_state_dict'])
+                elif model_fine is not None: # Fine model exists, but not in checkpoint
+                    print("Warning: Fine model enabled, but 'model_fine_state_dict' not in checkpoint. Fine model weights are not loaded from checkpoint.")
+                elif 'model_fine_state_dict' in checkpoint: # Fine model in checkpoint, but not enabled
+                    print("Warning: Checkpoint contains 'model_fine_state_dict', but fine model is not currently enabled. It will not be loaded.")
+
+                optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+
+                start_epoch = checkpoint.get('epoch', -1) + 1 # Start from NEXT epoch
+                global_step = checkpoint.get('global_step', 0)
+
+                print(f"Successfully resumed from epoch {start_epoch}, global_step {global_step}.")
+                # Optionally print or compare checkpoint['args_saved_at_checkpoint']
+            except Exception as e:
+                print(f"Error loading checkpoint '{resolved_path}': {e}. Starting training from scratch.")
+                start_epoch = 0 # Reset epoch and step if loading fails
+                global_step = 0
+        else:
+            print(f"Checkpoint file '{checkpoint_path_arg}' not found. Starting training from scratch.")
+
+    # SummaryWriter
+    tb_writer_path = os.path.join(args.basedir, args.expname, 'tensorboard')
+    os.makedirs(tb_writer_path, exist_ok=True)
+    writer = SummaryWriter(tb_writer_path)
+    print(f"Tensorboard logs will be saved to: {tb_writer_path}")
+
+    # Note: start_epoch and global_step are initialized before checkpoint loading logic now.
+    print("Initial training state: start_epoch={}, global_step={}".format(start_epoch, global_step))
+
+    print("Starting training...")
+
+    for epoch in range(start_epoch, args.num_epochs):
+        model_coarse.train()
+        if model_fine:
+            model_fine.train()
+
+        epoch_loss_sum = 0.0
+        batch_iterator = tqdm(train_loader, desc=f"Epoch {epoch+1}/{args.num_epochs}", leave=True)
+
+        for batch_idx, data_batch in enumerate(batch_iterator):
+            rays_o = data_batch['rays_o'].to(device)
+            rays_d = data_batch['rays_d'].to(device)
+            target_rgb = data_batch['target_rgb'].to(device)
+
+            # Manual learning rate decay (exponential)
+            current_lr = args.lr * (args.lr_decay_factor**(global_step / args.lr_decay_steps))
+            for param_group in optimizer.param_groups:
+                param_group['lr'] = current_lr
+
+            # Coarse pass
+            coarse_results = render_rays(
+                nerf_model=model_coarse, embed_fn_pts=embed_fn_pts, embed_fn_views=embed_fn_views,
+                rays_o=rays_o, rays_d=rays_d, near=args.near, far=args.far,
+                N_samples=args.N_samples_coarse, rand=True, lindisp=args.lindisp,
+                use_viewdirs=args.use_viewdirs, white_bkgd=args.white_bkgd
+            )
+            loss_coarse = torch.mean((coarse_results['rgb_map'] - target_rgb)**2)
+            total_loss = loss_coarse
+
+            # Fine pass (hierarchical sampling)
+            if args.use_hierarchical and model_fine:
+                with torch.no_grad():
+                    z_vals_coarse = coarse_results['z_vals'].detach()
+                    weights_coarse = coarse_results['weights'].detach()
+
+                    # Calculate midpoints of z_vals for PDF sampling bins
+                    z_vals_mid = 0.5 * (z_vals_coarse[..., 1:] + z_vals_coarse[..., :-1])
+                    # Using weights for PDF, can also use alpha values
+                    # Add small epsilon to prevent issues with zero weights
+                    weights_pdf = weights_coarse[..., 1:-1] + 1e-5 # Exclude first and last weight for midpoints
+
+                    z_samples_fine = sample_pdf(bins=z_vals_mid, weights=weights_pdf,
+                                                N_samples=args.N_samples_fine, det=False) # det=True for testing, False for training
+
+                # Combine coarse and fine samples, sort them
+                z_vals_combined, _ = torch.sort(torch.cat([z_vals_coarse, z_samples_fine], dim=-1), dim=-1)
+
+                # Render with fine model using combined samples
+                fine_results = render_rays(
+                    nerf_model=model_fine, embed_fn_pts=embed_fn_pts, embed_fn_views=embed_fn_views,
+                    rays_o=rays_o, rays_d=rays_d, near=args.near, far=args.far, # near/far might not be strictly needed if z_vals_override is full
+                    N_samples=z_vals_combined.shape[-1], # This will be ignored due to z_vals_override
+                    rand=True, lindisp=args.lindisp, use_viewdirs=args.use_viewdirs,
+                    white_bkgd=args.white_bkgd, z_vals_override=z_vals_combined
+                )
+                loss_fine = torch.mean((fine_results['rgb_map'] - target_rgb)**2)
+                total_loss += loss_fine
+
+            optimizer.zero_grad()
+            total_loss.backward()
+            optimizer.step()
+
+            epoch_loss_sum += total_loss.item()
+            global_step += 1
+
+            # Logging
+            if global_step % args.log_freq == 0:
+                psnr_coarse_val = -10. * torch.log10(loss_coarse.detach()) if loss_coarse > 0 else torch.tensor(0.0)
+                writer.add_scalar('Loss/total_train', total_loss.item(), global_step)
+                writer.add_scalar('Loss/coarse_train', loss_coarse.item(), global_step)
+                writer.add_scalar('PSNR/coarse_train', psnr_coarse_val.item(), global_step)
+                writer.add_scalar('LearningRate', current_lr, global_step)
+
+                log_message_parts = [f"GS: {global_step}", f"LR: {current_lr:.7f}",
+                                     f"Loss_T: {total_loss.item():.4f}", f"PSNR_c: {psnr_coarse_val.item():.2f}"]
+                if args.use_hierarchical and model_fine and 'loss_fine' in locals():
+                    psnr_fine_val = -10. * torch.log10(loss_fine.detach()) if loss_fine > 0 else torch.tensor(0.0)
+                    writer.add_scalar('Loss/fine_train', loss_fine.item(), global_step)
+                    writer.add_scalar('PSNR/fine_train', psnr_fine_val.item(), global_step)
+                    log_message_parts.extend([f"Loss_f: {loss_fine.item():.4f}", f"PSNR_f: {psnr_fine_val.item():.2f}"])
+
+                batch_iterator.set_postfix_str(" ".join(log_message_parts), refresh=True)
+
+            # Validation image rendering (placeholder)
+            if global_step > 0 and global_step % args.val_img_freq == 0:
+                tqdm.write(f"\nStep {global_step}: Rendering validation image (placeholder)...")
+                # TODO: Implement validation image rendering logic
+                # e.g., take a fixed image from val_loader, render it, save to imageio, log to tensorboard
+                pass
+
+        avg_epoch_loss = epoch_loss_sum / len(train_loader)
+        tqdm.write(f"Epoch {epoch+1} completed. Average Loss: {avg_epoch_loss:.4f}. Global Step: {global_step}")
+
+        # Save checkpoint
+        if (epoch + 1) % args.save_freq == 0:
+            save_checkpoint(epoch, global_step, model_coarse, model_fine, optimizer, args)
+
+    print("Saving final checkpoint...")
+    save_checkpoint(args.num_epochs - 1, global_step, model_coarse, model_fine, optimizer, args, is_final=True)
+
+    writer.close()
+    print("Training complete.")
+
+# Define save_checkpoint function here or ensure it's imported if defined elsewhere
+def save_checkpoint(epoch, global_step, model_coarse, model_fine, optimizer, args, is_final=False):
+    checkpoint_dir = os.path.join(args.basedir, args.expname, 'checkpoints')
+    os.makedirs(checkpoint_dir, exist_ok=True)
+
+    checkpoint_filename = f'checkpoint_epoch_{epoch:04d}_step_{global_step:07d}.pth'
+    if is_final: # Use epoch as the actual last completed epoch for final save
+        checkpoint_filename = f'checkpoint_final_epoch_{epoch:04d}_step_{global_step:07d}.pth'
+
+    checkpoint_path = os.path.join(checkpoint_dir, checkpoint_filename)
+
+    save_dict = {
+        'epoch': epoch, # The epoch just completed
+        'global_step': global_step,
+        'args_saved_at_checkpoint': vars(args),
+        'model_coarse_state_dict': model_coarse.state_dict(),
+        'optimizer_state_dict': optimizer.state_dict(),
+    }
+    if model_fine is not None:
+        save_dict['model_fine_state_dict'] = model_fine.state_dict()
+
+    torch.save(save_dict, checkpoint_path)
+    print(f"Checkpoint saved to {checkpoint_path}")
+
+    if not is_final: # Also save as 'latest.pth' for easy resume
+        latest_path = os.path.join(checkpoint_dir, 'latest.pth')
+        torch.save(save_dict, latest_path)
+        print(f"Latest checkpoint updated at {latest_path}")
+
+
+if __name__ == '__main__':
+    train()

--- a/src/datasets/blender.py
+++ b/src/datasets/blender.py
@@ -1,0 +1,155 @@
+import torch
+import os
+import json
+import numpy as np
+import imageio
+
+class BlenderDataset(torch.utils.data.Dataset):
+    def __init__(self, dataset_path, split, transform=None, data_white_bkgd=False):
+        self.dataset_path = dataset_path
+        self.split = split
+        self.transform = transform
+        self.data_white_bkgd = data_white_bkgd
+
+        self.image_paths = []
+        self.poses = []
+        self.all_rgbs = [] # Store all images in memory
+        self.focal = None
+        self.height = None
+        self.width = None
+
+        json_path = os.path.join(self.dataset_path, f"transforms_{self.split}.json")
+        with open(json_path, 'r') as f:
+            meta = json.load(f)
+
+        camera_angle_x = float(meta['camera_angle_x'])
+
+        for frame in meta['frames']:
+            img_path = os.path.join(self.dataset_path, frame['file_path'] + '.png')
+            self.image_paths.append(img_path)
+            self.poses.append(np.array(frame['transform_matrix']))
+
+            img = imageio.imread(img_path)
+            if self.height is None or self.width is None:
+                self.height, self.width = img.shape[:2]
+
+            image = (np.array(img) / 255.0).astype(np.float32)
+
+            if image.shape[-1] == 4: # RGBA
+                if self.data_white_bkgd:
+                    # Blend RGB onto white background using alpha
+                    image = image[...,:3] * image[...,-1:] + (1.0 - image[...,-1:])
+                else:
+                    # Blend RGB onto black background using alpha
+                    image = image[...,:3] * image[...,-1:]
+            # Now image is RGB
+            self.all_rgbs.append(image) # Append numpy array, convert to tensor later
+
+        self.poses = torch.from_numpy(np.array(self.poses)).float()
+        # Convert list of numpy arrays to a single tensor
+        self.all_rgbs = torch.from_numpy(np.array(self.all_rgbs)).float() # N_images, H, W, 3
+
+
+        if self.width: # Ensure width is loaded
+             self.focal = 0.5 * self.width / np.tan(0.5 * camera_angle_x)
+        else:
+            # Handle case where no images are loaded (e.g., empty split)
+            # Or if first image failed to load, though imageio.imread would raise error
+            print("Warning: Image width not available, focal length cannot be calculated.")
+
+
+    def __len__(self):
+        return len(self.image_paths)
+
+    def __getitem__(self, idx):
+        pose = self.poses[idx] # Get camera-to-world matrix
+        rgb_target = self.all_rgbs[idx] # H, W, 3
+
+        rays_o, rays_d = get_rays(self.height, self.width, self.focal, pose)
+
+        if self.split == 'train':
+            rays_o = rays_o.reshape(-1, 3) # (H*W, 3)
+            rays_d = rays_d.reshape(-1, 3) # (H*W, 3)
+            rgb_target = rgb_target.reshape(-1, 3) # (H*W, 3)
+            return {"rays_o": rays_o, "rays_d": rays_d, "target_rgb": rgb_target}
+        else: # 'val' or 'test'
+            # For validation/testing, we return per-image rays and targets
+            return {"rays_o": rays_o, "rays_d": rays_d, "target_rgb": rgb_target, "pose": pose}
+
+# Helper function to generate rays
+# Conventions:
+# Image coordinate origin: Top-left. j (row index) increases downwards, i (column index) increases rightwards.
+# Camera coordinate system: X right, Y down, Z inward (camera looks along positive Z).
+# This is a common convention for NeRF. Blender's export might be different (often Z-up).
+# The c2w matrices from Blender datasets are typically OpenGL convention (Y down, Z inward if camera at origin looking towards +Z).
+# If c2w[:3,2] (Z-axis of camera in world coords) points towards scene, then camera looks along +Z in its own space.
+# Ray directions are then (i - W/2)/f, (j - H/2)/f, 1.0
+def get_rays(H, W, focal, c2w):
+    """
+    Generate rays for a given camera.
+    Args:
+        H (int): Image height.
+        W (int): Image width.
+        focal (float): Focal length.
+        c2w (torch.Tensor): Camera-to-world transformation matrix [4, 4] or [3, 4].
+    Returns:
+        rays_o (torch.Tensor): Ray origins [H, W, 3].
+        rays_d (torch.Tensor): Ray directions [H, W, 3].
+    """
+    # PyTorch meshgrid produces y-coordinates first (rows), then x-coordinates (columns)
+    # Indexing='ij' makes it behave like np.meshgrid (x first, then y)
+    # We want j (rows, from 0 to H-1) and i (cols, from 0 to W-1)
+    j, i = torch.meshgrid(torch.arange(H, dtype=torch.float32), torch.arange(W, dtype=torch.float32), indexing='xy')
+    # Transpose i, j to match image layout (H, W) after meshgrid gives (W,H) if indexing='xy'
+    # Actually, indexing='ij' is what we want for (H,W) for j and (H,W) for i. Let's use default indexing='xy' then transpose.
+    # Or simpler: use indexing='ij', then j is (H,W) and i is (H,W)
+
+    # Using indexing='ij' for torch.meshgrid:
+    # ii, jj = torch.meshgrid(torch.linspace(0, W-1, W), torch.linspace(0, H-1, H), indexing='ij')
+    # This results in ii of shape (W,H) and jj of shape (W,H)
+    # Let's use indexing='xy' and be careful:
+    # i, j = torch.meshgrid(torch.linspace(0, W-1, W), torch.linspace(0, H-1, H), indexing='xy')
+    # i will be (W, H), j will be (W, H). Transpose them to (H, W)
+    # i = i.transpose(0,1)
+    # j = j.transpose(0,1)
+
+    # Let's try again:
+    # We need i to go from 0 to W-1 for each row, and j to go from 0 to H-1 for each column.
+    # torch.meshgrid(torch.arange(W), torch.arange(H), indexing='ij') -> i (W,H), j (W,H)
+    # torch.meshgrid(torch.arange(H), torch.arange(W), indexing='xy') -> j (H,W), i (H,W) This seems right.
+
+    # Let's be explicit:
+    pixels_y, pixels_x = torch.meshgrid(torch.arange(H, dtype=torch.float32), torch.arange(W, dtype=torch.float32), indexing='ij')
+    # pixels_x: (H, W), values from 0 to W-1
+    # pixels_y: (H, W), values from 0 to H-1
+
+    # Camera coordinate directions
+    # (x,y,z) in camera space: x right, y down, z forward (into scene)
+    # Pixel (i,j) corresponds to camera coordinates ( (i - W/2), (j - H/2) ) on the image plane.
+    # The ray direction is then ((i - W/2)/f, (j - H/2)/f, 1) for a camera looking along +Z.
+    # If camera looks along -Z (OpenGL convention), then ((i - W/2)/f, (j - H/2)/f, -1).
+    # The Blender dataset c2w matrices typically transform from OpenGL camera coords (Y-down, X-right, Camera looking -Z) to world.
+
+    dirs_x = (pixels_x - W * 0.5) / focal
+    dirs_y = (pixels_y - H * 0.5) / focal # Y positive downwards in image, Y positive downwards in camera
+    dirs_z = -torch.ones_like(dirs_x) # Camera looks along -Z axis in its own coordinate system
+
+    dirs_cam = torch.stack([dirs_x, dirs_y, dirs_z], dim=-1) # Shape: [H, W, 3]
+
+    # Transform directions from camera to world space
+    # c2w is [4, 4]. Rotation part is c2w[:3, :3]
+    # rays_d = dirs_cam @ c2w[:3, :3].T # This would be if dirs_cam was a row vector
+    # Correct way: R * d_cam where d_cam is a column vector.
+    # Here dirs_cam is (H,W,3). We want to transform each (3,) vector.
+    # So, (R @ d.T).T = d @ R.T
+    # rays_d = torch.einsum('hwk,jk->hwj', dirs_cam, c2w[:3,:3]) # k is camera coord index, j is world coord index
+    # Or simply:
+    rays_d = torch.sum(dirs_cam[..., None, :] * c2w[:3, :3], dim=-1) # dirs_cam (H,W,1,3) * R (3,3) -> sum over last dim
+
+    # Normalize ray directions
+    rays_d = rays_d / torch.norm(rays_d, dim=-1, keepdim=True)
+
+    # Ray origins are the camera center in world coordinates
+    rays_o = c2w[:3, -1].expand(rays_d.shape) # c2w[:3, -1] is (3,), expand to (H, W, 3)
+
+    return rays_o.contiguous(), rays_d.contiguous()

--- a/src/models/nerf.py
+++ b/src/models/nerf.py
@@ -1,0 +1,589 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+
+class PositionalEncoder(nn.Module):
+    def __init__(self, input_dims, num_freqs, log_sampling=True):
+        """
+        Initializes the PositionalEncoder.
+        Args:
+            input_dims (int): Dimensionality of the input.
+            num_freqs (int): Number of frequencies L.
+            log_sampling (bool): Whether to sample frequencies in log scale.
+        """
+        super().__init__()
+        self.input_dims = input_dims
+        self.num_freqs = num_freqs
+        self.log_sampling = log_sampling
+
+        if self.log_sampling:
+            self.freq_bands = 2.**torch.linspace(0., num_freqs - 1, num_freqs)
+        else:
+            freq_bands = torch.linspace(1., 2.**(num_freqs - 1), num_freqs)
+
+        self.register_buffer('freq_bands', freq_bands if 'freq_bands' in locals() else 2.**torch.linspace(0., num_freqs - 1, num_freqs))
+        # Output dimension: original input_dims + input_dims * 2 * num_freqs for sin and cos
+        self.output_dims = self.input_dims + self.input_dims * 2 * self.num_freqs
+
+    def forward(self, x):
+        """
+        Applies positional encoding to the input tensor.
+        Args:
+            x (torch.Tensor): Input tensor of shape [N, ..., input_dims].
+        Returns:
+            torch.Tensor: Encoded tensor of shape [N, ..., output_dims].
+        """
+        outputs = [x] # Include the original input
+        for freq in self.freq_bands:
+            outputs.append(torch.sin(x * freq))
+            outputs.append(torch.cos(x * freq))
+
+        return torch.cat(outputs, dim=-1)
+
+if __name__ == '__main__':
+    # Example Usage
+    input_dim = 3
+    L = 10
+    encoder = PositionalEncoder(input_dim, L)
+    print(f"Output dimensions: {encoder.output_dims}") # Expected: 3 + 3*2*10 = 63
+
+    # Test with a sample tensor
+    # Batch of 2, sequence of 5 points, each 3D
+    test_input = torch.rand(2, 5, input_dim)
+    encoded_output = encoder(test_input)
+    print(f"Input shape: {test_input.shape}")
+    print(f"Encoded output shape: {encoded_output.shape}") # Expected: [2, 5, 63]
+
+    # Test with a single point
+    test_single_input = torch.rand(input_dim)
+    encoded_single_output = encoder(test_single_input)
+    print(f"Single input shape: {test_single_input.shape}")
+    print(f"Encoded single output shape: {encoded_single_output.shape}") # Expected: [63]
+
+    # Test with batch of points (N, D)
+    test_batch_points = torch.rand(100, input_dim)
+    encoded_batch_points = encoder(test_batch_points)
+    print(f"Batch points input shape: {test_batch_points.shape}")
+    print(f"Encoded batch points output shape: {encoded_batch_points.shape}") # Expected: [100, 63]
+
+    # Test different input_dims and L
+    encoder_2d_L4 = PositionalEncoder(input_dims=2, num_freqs=4)
+    print(f"2D L=4 Output dimensions: {encoder_2d_L4.output_dims}") # Expected: 2 + 2*2*4 = 18
+    test_input_2d = torch.rand(3, 2)
+    encoded_output_2d = encoder_2d_L4(test_input_2d)
+    print(f"2D L=4 Input shape: {test_input_2d.shape}")
+    print(f"2D L=4 Encoded output shape: {encoded_output_2d.shape}") # Expected: [3, 18]
+
+    # Test with log_sampling=False
+    encoder_linear_sampling = PositionalEncoder(input_dim, L, log_sampling=False)
+    print(f"Output dimensions (linear): {encoder_linear_sampling.output_dims}")
+    encoded_output_linear = encoder_linear_sampling(test_input)
+    print(f"Encoded output shape (linear): {encoded_output_linear.shape}")
+
+    assert encoded_output.shape[-1] == encoder.output_dims
+    assert encoded_single_output.shape[-1] == encoder.output_dims
+    assert encoded_batch_points.shape[-1] == encoder.output_dims
+    assert encoded_output_2d.shape[-1] == encoder_2d_L4.output_dims
+    assert encoded_output_linear.shape[-1] == encoder_linear_sampling.output_dims
+    print("PositionalEncoder tests passed.")
+
+
+class NeRF(nn.Module):
+    def __init__(self, D=8, W=256, input_ch_pts=63, input_ch_views=27, skips=[4], use_viewdirs=True):
+        """
+        Initializes the NeRF model.
+        Args:
+            D (int): Number of linear layers in the main network.
+            W (int): Number of hidden units per layer.
+            input_ch_pts (int): Number of channels for encoded input 3D coordinates.
+            input_ch_views (int): Number of channels for encoded input viewing directions.
+            skips (list of int): List of layer indices where residual connections should be added.
+            use_viewdirs (bool): Whether to use viewing directions.
+        """
+        super(NeRF, self).__init__()
+        self.D = D
+        self.W = W
+        self.input_ch_pts = input_ch_pts
+        self.input_ch_views = input_ch_views
+        self.skips = skips
+        self.use_viewdirs = use_viewdirs
+
+        # Layers for processing spatial coordinates (pts_linears)
+        self.pts_linears = nn.ModuleList()
+        self.pts_linears.append(nn.Linear(input_ch_pts, W))
+        for i in range(D - 1):
+            if i in self.skips:
+                self.pts_linears.append(nn.Linear(W + input_ch_pts, W))
+            else:
+                self.pts_linears.append(nn.Linear(W, W))
+
+        # Layers for output
+        if use_viewdirs:
+            self.sigma_linear = nn.Linear(W, 1)  # For sigma (density)
+            self.feature_linear = nn.Linear(W, W) # To get feature vector
+
+            # Layers for predicting RGB using features and view directions
+            self.rgb_layers = nn.Sequential(
+                nn.Linear(W + input_ch_views, W // 2),
+                nn.ReLU(),
+                nn.Linear(W // 2, 3)
+            )
+        else:
+            # If not using view directions, predict RGB and sigma directly from the main network's output
+            self.output_linear = nn.Linear(W, 4)  # Output: RGB (3) + Sigma (1)
+
+    def forward(self, x_pts_encoded, x_views_encoded=None):
+        """
+        Forward pass of the NeRF model.
+        Args:
+            x_pts_encoded (torch.Tensor): Encoded 3D coordinates. Shape: [N, ..., input_ch_pts].
+            x_views_encoded (torch.Tensor, optional): Encoded viewing directions. Shape: [N, ..., input_ch_views].
+                                                     Required if use_viewdirs is True.
+        Returns:
+            torch.Tensor: Output tensor containing RGB (3 channels) and sigma (1 channel). Shape: [N, ..., 4].
+        """
+        h = x_pts_encoded
+        for i, layer in enumerate(self.pts_linears):
+            h = layer(h)
+            h = nn.functional.relu(h)
+            if i in self.skips and i < len(self.pts_linears) -1 : # Make sure skip connection is not applied after last layer of pts_linears before feature_linear/output_linear
+                h = torch.cat([x_pts_encoded, h], -1)
+
+        if self.use_viewdirs:
+            if x_views_encoded is None:
+                raise ValueError("View directions (x_views_encoded) must be provided when use_viewdirs is True.")
+
+            sigma = self.sigma_linear(h)
+            features = self.feature_linear(h)
+
+            combined = torch.cat([features, x_views_encoded], -1)
+            rgb = self.rgb_layers(combined)
+        else:
+            outputs = self.output_linear(h)
+            rgb = outputs[..., :3]
+            sigma = outputs[..., 3:4] # Keep last dim as 1 for sigma
+
+        return torch.cat([rgb, sigma], -1)
+
+
+if __name__ == '__main__':
+    # Example Usage for NeRF model
+    # Positional Encoders (already tested above, but let's make instances for NeRF)
+    L_pts = 10
+    L_views = 4
+    pts_encoder = PositionalEncoder(3, L_pts)
+    views_encoder = PositionalEncoder(3, L_views) # Assuming 3D view directions (unit vectors)
+
+    input_ch_pts = pts_encoder.output_dims # 3 + 3*2*10 = 63
+    input_ch_views = views_encoder.output_dims # 3 + 3*2*4 = 27
+
+    # Test NeRF with view directions
+    nerf_model_vd = NeRF(input_ch_pts=input_ch_pts, input_ch_views=input_ch_views, use_viewdirs=True)
+
+    # Create dummy input
+    batch_size = 4
+    num_points = 1024 # e.g. rays in a batch
+    raw_pts = torch.rand(batch_size, num_points, 3)
+    raw_views = torch.rand(batch_size, num_points, 3)
+    raw_views = raw_views / torch.norm(raw_views, dim=-1, keepdim=True) # Normalize view directions
+
+    encoded_pts = pts_encoder(raw_pts)
+    encoded_views = views_encoder(raw_views)
+
+    print(f"\n--- NeRF with view directions ---")
+    print(f"Raw pts shape: {raw_pts.shape}")
+    print(f"Encoded pts shape: {encoded_pts.shape}") # Expected: [B, N, 63]
+    print(f"Raw views shape: {raw_views.shape}")
+    print(f"Encoded views shape: {encoded_views.shape}") # Expected: [B, N, 27]
+
+    output_vd = nerf_model_vd(encoded_pts, encoded_views)
+    print(f"Output shape (with viewdirs): {output_vd.shape}") # Expected: [B, N, 4]
+    assert output_vd.shape == (batch_size, num_points, 4)
+
+    # Test NeRF without view directions
+    nerf_model_no_vd = NeRF(input_ch_pts=input_ch_pts, use_viewdirs=False)
+    print(f"\n--- NeRF without view directions ---")
+    output_no_vd = nerf_model_no_vd(encoded_pts) # x_views_encoded is None
+    print(f"Output shape (without viewdirs): {output_no_vd.shape}") # Expected: [B, N, 4]
+    assert output_no_vd.shape == (batch_size, num_points, 4)
+
+    # Test skip connection logic carefully
+    # A skip connection happens AT layer i (meaning, after layer i-1's output, before layer i's input)
+    # The current pts_linears definition:
+    # self.pts_linears.append(nn.Linear(input_ch_pts, W)) -> layer 0
+    # for i in range(D - 1): -> i from 0 to D-2
+    #   if i in self.skips: self.pts_linears.append(nn.Linear(W + input_ch_pts, W)) -> this is layer i+1
+    #   else: self.pts_linears.append(nn.Linear(W, W)) -> this is layer i+1
+    # So, if skips=[4], it means layer 5 (index 4 in the loop, which is pts_linears[4+1]) gets concatenated input.
+    # Forward pass:
+    # for i, layer in enumerate(self.pts_linears):
+    #   h = layer(h)
+    #   ...
+    #   if i in self.skips: h = torch.cat([x_pts_encoded, h], -1)
+    # This means if i=4 is in skips, after layer 4 (pts_linears[4]) computes, its output is concatenated with original x_pts_encoded.
+    # This concatenated result becomes input for layer 5 (pts_linears[5]).
+    # So, pts_linears[5] should be nn.Linear(W + input_ch_pts, W).
+    # Let's trace for D=8, skips=[4]
+    # pts_linears[0]: Linear(input_ch_pts, W)
+    # Loop i = 0..6:
+    # i=0: pts_linears[1] = Linear(W,W)
+    # i=1: pts_linears[2] = Linear(W,W)
+    # i=2: pts_linears[3] = Linear(W,W)
+    # i=3: pts_linears[4] = Linear(W,W) (This is the layer *before* the one that takes skip connection)
+    # i=4: (i=4 is in skips) pts_linears[5] = Linear(W + input_ch_pts, W)
+    # i=5: pts_linears[6] = Linear(W,W)
+    # i=6: pts_linears[7] = Linear(W,W)
+    # Total D=8 layers (indices 0 to 7).
+    # Forward pass:
+    # h = x_pts_encoded
+    # i=0: h = relu(pts_linears[0](h))
+    # i=1: h = relu(pts_linears[1](h))
+    # i=2: h = relu(pts_linears[2](h))
+    # i=3: h = relu(pts_linears[3](h))
+    # i=4: h = relu(pts_linears[4](h)). Now i=4 is in skips. h = cat(x_pts_encoded, h). This h is input to pts_linears[5].
+    # This matches the original NeRF paper: "concatenate with the original input".
+    # The condition `i < len(self.pts_linears) -1` in forward for skip connection is important.
+    # A skip connection should not be applied after the *final* layer of pts_linears,
+    # because that `h` is then used for sigma_linear or output_linear.
+    # The loop for pts_linears goes up to D-1.
+    # If D-1 is in skips, then after the last layer, it would concat. This is usually not intended.
+    # Original NeRF: "input to the 5th layer (index 4) is the concatenation of the output of the 4th layer and the original input"
+    # This means after layer index 3's output, we concat and pass to layer index 4.
+    # My current code: if 4 is in skips, after layer `pts_linears[4]` output, we concat.
+    # This means `pts_linears[5]` takes the concatenated input.
+    # The original paper's diagram shows skip from input to layer 4.
+    # If layers are 0..8 (9 layers total, D=9 in paper for pts path), skip is to input of layer 4.
+    # My D is number of layers. If D=8, layers 0..7.
+    # If skips=[4], it means input to layer 5 (index 4 in the loop creating layers 1 to D-1) is concatenated.
+    # Let's re-check the `pts_linears` construction logic.
+    # `self.pts_linears.append(nn.Linear(input_ch_pts, W))` -> This is layer 0.
+    # Loop `for i in range(D - 1)`: (i goes from 0 to D-2)
+    #   `self.pts_linears.append(...)` -> This appends layer 1 to layer D-1.
+    #   Layer `j` (1-indexed in this loop description, so layer `i+1` in terms of list index)
+    #   If `i` (0 to D-2) is in `skips`, then layer `i+1` gets `W + input_ch_pts` as input dim.
+    #   Example: D=8, skips=[4].
+    #   Layer 0: Linear(input_ch_pts, W)
+    #   Loop i=0..6:
+    #   i=0: layer 1: Linear(W,W)
+    #   i=1: layer 2: Linear(W,W)
+    #   i=2: layer 3: Linear(W,W)
+    #   i=3: layer 4: Linear(W,W)
+    #   i=4: (4 is in skips) layer 5: Linear(W+input_ch_pts, W)
+    #   i=5: layer 6: Linear(W,W)
+    #   i=6: layer 7: Linear(W,W)
+    # This seems correct: layer 5 (index 5 in `self.pts_linears`) is the one that processes the concatenated features.
+    # The `forward` pass:
+    # `h = x_pts_encoded`
+    # `for i, layer in enumerate(self.pts_linears):` (i goes from 0 to D-1, matching layer index)
+    #   `h = layer(h)`
+    #   `h = nn.functional.relu(h)`
+    #   `if i in self.skips:` (e.g. i=4 is in skips)
+    #     `h = torch.cat([x_pts_encoded, h], -1)`
+    # This means the output of layer 4 (index 4) is concatenated with `x_pts_encoded`.
+    # This concatenated `h` then becomes the input to layer 5 (index 5). This is correct.
+    # The condition `i < len(self.pts_linears) -1` for skip connection application is good.
+    # If `skips` contained `D-1`, the output of the last layer would be concatenated, then immediately used by `sigma_linear` etc.
+    # This would change the input dimension to `sigma_linear` if `D-1` was a skip index.
+    # The current code is fine. `skips` should contain indices from `0` to `D-2`.
+    # (If `skips` contains `k`, then layer `k+1` is the one that receives the concatenated input).
+    # The original paper mentions D=8 layers for the main MLP. This means indices 0 through 7.
+    # And skip connection at layer 4. This means layer with index 4 (the 5th layer) receives concatenated input.
+    # So if my D=8, then skips should be [3] for layer 4 to get concatenated input.
+    # (After layer 3's output, concat, then feed to layer 4).
+    # Let's adjust the interpretation: `skips` are the layers *whose output* gets concatenated.
+    # No, the standard is: `skips` are layer indices `k` such that layer `k+1` takes `[output_of_k, original_input]`.
+    # My current code: `if i in self.skips: h = torch.cat([x_pts_encoded, h], -1)`. `h` here is output of layer `i`.
+    # So layer `i+1` receives this concatenated `h`.
+    # So if `skips = [4]`, layer 5 receives concatenated input. This matches "input to the 5th layer".
+    # The number of layers D counts the first layer too. So D=8 means layers 0,1,2,3,4,5,6,7.
+    # This means my `skips=[4]` is consistent with original NeRF (input to 5th layer, which is index 4).
+    # The `range(D-1)` in `__init__` creates `D-1` layers. Plus the first one, makes `D` layers.
+    # `pts_linears` will have length `D`. Indices `0` to `D-1`.
+    # If `skips=[4]`, and `D=8`.
+    # In `__init__`: `i` goes from `0` to `6`.
+    # `layer_idx_in_list = i + 1`.
+    # If `i=4` is in `skips`, then `pts_linears[5]` is `Linear(W+input_ch_pts, W)`.
+    # In `forward`: `i` goes `0` to `D-1` (i.e. `0..7`).
+    # If `i=4` (which is `pts_linears[4]`), its output `h` is taken. `h = cat(x_pts, h)`.
+    # This `h` is fed to `pts_linears[5]`. This is correct.
+    print("NeRF model tests seem okay.")
+
+
+# Hierarchical sampling helper
+def sample_pdf(bins, weights, N_samples, det=False):
+    """
+    Sample @N_samples more points from @bins with distribution defined by @weights.
+    Args:
+        bins (torch.Tensor): [N_rays, N_samples_coarse - 1]. Midpoints of coarse samples.
+        weights (torch.Tensor): [N_rays, N_samples_coarse - 1]. Weights for each bin.
+        N_samples (int): Number of samples to draw (N_importance).
+        det (bool): If True, deterministic sampling (linspace in CDF), else stochastic.
+    Returns:
+        samples (torch.Tensor): [N_rays, N_samples]. Fine samples.
+    """
+    # Add a small epsilon to weights to prevent NaN issues if all weights are zero.
+    weights = weights + 1e-5  # [N_rays, N_samples_coarse - 1]
+    pdf = weights / torch.sum(weights, -1, keepdim=True)  # [N_rays, N_samples_coarse - 1]
+    cdf = torch.cumsum(pdf, -1)  # [N_rays, N_samples_coarse - 1]
+    # Prepend zeros to CDF to have a starting point for searchsorted.
+    cdf = torch.cat([torch.zeros_like(cdf[..., :1]), cdf], -1)  # [N_rays, N_samples_coarse]
+
+    if det:
+        u = torch.linspace(0., 1., steps=N_samples, device=bins.device)
+        u = u.expand(list(cdf.shape[:-1]) + [N_samples]) # [N_rays, N_samples]
+    else:
+        u = torch.rand(list(cdf.shape[:-1]) + [N_samples], device=bins.device) # [N_rays, N_samples]
+
+    u = u.contiguous() # Ensure contiguity for searchsorted
+
+    # Find indices where `u` would be inserted into `cdf` to maintain order.
+    # `right=True` means that if u[i] is equal to cdf[j], then inds[i] = j+1
+    inds = torch.searchsorted(cdf, u, right=True) # [N_rays, N_samples]
+
+    # Calculate lower and upper bin indices for interpolation
+    below = torch.max(torch.zeros_like(inds - 1), inds - 1) # [N_rays, N_samples]
+    above = torch.min((cdf.shape[-1] - 1) * torch.ones_like(inds), inds) # [N_rays, N_samples]
+
+    # Stack for gathering: shape [N_rays, N_samples, 2]
+    inds_g = torch.stack([below, above], -1)
+
+    # Gather CDF values and bin values corresponding to these indices
+    # cdf_g will have shape [N_rays, N_samples, 2]
+    # inds_g.view(-1,2) has shape [N_rays*N_samples, 2]
+    # cdf has shape [N_rays, N_samples_coarse]
+    # We want to gather along the last dimension of cdf.
+    # Matched_cdf_values = cdf[..., inds_g] does not work due to shape mismatch
+    # Need to expand cdf or use gather carefully
+
+    # For gather, input tensor and index tensor must have same number of dimensions,
+    # except for the dimension specified by `dim`.
+    # cdf: [N_rays, N_samples_coarse]
+    # inds_g: [N_rays, N_samples, 2]
+    # We want to select N_samples_coarse values for each of the N_rays.
+    # The indices in inds_g are for the N_samples_coarse dimension.
+
+    # Reshape inds_g to [N_rays, N_samples * 2] then gather, then reshape back.
+    # Or, more simply, expand cdf and bins to match inds_g's N_samples dimension.
+    # cdf_expanded = cdf.unsqueeze(1).expand(cdf.shape[0], N_samples, cdf.shape[1])
+    # cdf_g = torch.gather(cdf_expanded, 2, inds_g)
+
+    # Alternative gather:
+    # The gather is tricky. Let's use view and then gather.
+    # N_rays, N_samples_coarse = cdf.shape
+    # _, N_fine_samples, _ = inds_g.shape
+    # cdf_g = torch.gather(cdf.unsqueeze(1).repeat(1,N_fine_samples,1), 2, inds_g)
+    # bins_g = torch.gather(bins.unsqueeze(1).repeat(1,N_fine_samples,1), 2, inds_g)
+
+    # A simpler approach for gather:
+    # Flatten inds_g for batch gather, then reshape.
+    # This selects values from cdf for each ray based on the indices in inds_g.
+    # cdf_g = torch.gather(cdf, -1, inds_g.view(inds_g.shape[0], -1)).view(inds_g.shape)
+    # This is not quite right. Need to ensure that for each ray, we are indexing into its own CDF.
+    # The `torch.gather` documentation:
+    # out[i][j][k] = input[i][index[i][j][k]][k]  # if dim == 1
+    # out[i][j][k] = input[i][j][index[i][j][k]]  # if dim == 2 (our case, dim=-1)
+
+    # Let's make sure the shapes are compatible for batch gather
+    # cdf is [N_rays, N_samples_coarse]
+    # inds_g is [N_rays, N_samples, 2]
+    # Goal: cdf_g is [N_rays, N_samples, 2] where cdf_g[r, s, 0] = cdf[r, inds_g[r,s,0]]
+
+    # We can iterate or use a more advanced gather.
+    # For simplicity, let's prepare dummy indices for the batch dimension of cdf.
+    batch_size = cdf.shape[0]
+    # This will create indices for the first dimension
+    idx_dim0 = torch.arange(batch_size, device=bins.device).view(-1, 1, 1)
+    # Repeat for N_samples and for the 2 (below/above)
+    idx_dim0 = idx_dim0.expand(-1, N_samples, 2)
+
+    # Now we can use cdf[idx_dim0, inds_g] if this advanced indexing is supported as such
+    # PyTorch advanced indexing: x[idx_dim0, inds_g]
+    # cdf_g = cdf[idx_dim0, inds_g] # This works!
+    # bins_g = bins[idx_dim0, inds_g]
+
+    # Or, using gather:
+    # To use gather, cdf needs to be [N_rays, N_samples_coarse]
+    # inds_g is [N_rays, N_samples, 2].
+    # We need to gather along dim 1 (the N_samples_coarse dimension).
+    # cdf.gather(1, index_tensor_of_same_dim_as_cdf)
+    # So, inds_g needs to be reshaped or used carefully.
+
+    # Let's use the example from NeRF Pytorch code which is usually:
+    # cdf_g = torch.gather(cdf, dim=-1, index=inds_g.view(batch_size, -1))
+    # cdf_g = cdf_g.view(batch_size, N_samples, 2)
+    # This assumes cdf is [batch_size, num_bins] and inds_g is [batch_size, N_fine, 2]
+    # This seems fine:
+    cdf_g = torch.gather(cdf, dim=1, index=inds_g.view(batch_size, -1)).view(batch_size, N_samples, 2)
+    bins_g = torch.gather(bins, dim=1, index=inds_g.view(batch_size, -1)).view(batch_size, N_samples, 2)
+
+
+    # Linearly interpolate to get new t-samples
+    denom = (cdf_g[..., 1] - cdf_g[..., 0])
+    # Avoid division by zero if cdf_g[...,1] == cdf_g[...,0] (e.g. if a PDF bin is zero)
+    denom = torch.where(denom < 1e-5, torch.ones_like(denom), denom)
+    t = (u - cdf_g[..., 0]) / denom # [N_rays, N_samples]
+
+    samples = bins_g[..., 0] + t * (bins_g[..., 1] - bins_g[..., 0]) # [N_rays, N_samples]
+    return samples
+
+
+def render_rays(
+    nerf_model: NeRF,
+    embed_fn_pts, # PositionalEncoder for points
+    embed_fn_views, # PositionalEncoder for view directions
+    rays_o: torch.Tensor, # [N_rays, 3]
+    rays_d: torch.Tensor, # [N_rays, 3]
+    near: float,
+    far: float,
+    N_samples: int, # Number of coarse samples per ray
+    rand: bool = False, # If True, jitter samples
+    lindisp: bool = False, # If True, sample linearly in disparity, else linearly in depth
+    use_viewdirs: bool = True,
+    white_bkgd: bool = False,
+    z_vals_override: torch.Tensor = None # [N_rays, N_override_samples]
+):
+    """
+    Render rays using the NeRF model.
+    Args:
+        nerf_model: The NeRF nn.Module.
+        embed_fn_pts: Positional encoding function for 3D points.
+        embed_fn_views: Positional encoding function for view directions.
+        rays_o: Origins of rays [N_rays, 3].
+        rays_d: Directions of rays [N_rays, 3].
+        near: Near bound for sampling.
+        far: Far bound for sampling.
+        N_samples: Number of samples along each ray.
+        rand: If True, perturb sample positions.
+        lindisp: If True, sample linearly in disparity.
+        use_viewdirs: If True, use view directions in NeRF model.
+        white_bkgd: If True, composite RGB on a white background.
+    Returns:
+        A dictionary containing:
+        'rgb_map': [N_rays, 3]. Estimated RGB color of a ray.
+        'depth_map': [N_rays]. Estimated distance to object.
+        'disp_map': [N_rays]. Estimated disparity.
+        'acc_map': [N_rays]. Accumulated alpha.
+        'weights': [N_rays, N_samples]. Weights assigned to each sample point.
+        'z_vals': [N_rays, N_samples]. Depth of each sample point.
+        'alpha': [N_rays, N_samples]. Alpha values.
+        'raw_sigma': [N_rays, N_samples]. Raw sigma output from model.
+    """
+    N_rays = rays_o.shape[0]
+
+    # Determine z_vals for sampling
+    if z_vals_override is not None:
+        z_vals = z_vals_override
+        N_samples = z_vals.shape[-1] # Update N_samples to actual number of samples from override
+    else:
+        t_vals = torch.linspace(0., 1., steps=N_samples, device=rays_o.device) # Shape: [N_samples]
+
+        # Handle scalar or per-ray near/far
+        _near = near.view(-1, 1) if torch.is_tensor(near) and near.ndim > 0 and near.numel() > 1 else torch.tensor(near, device=rays_o.device).view(1,1)
+        _far = far.view(-1, 1) if torch.is_tensor(far) and far.ndim > 0 and far.numel() > 1 else torch.tensor(far, device=rays_o.device).view(1,1)
+
+
+        if lindisp:
+            z_vals_flat = 1. / (1. / _near * (1. - t_vals.view(1, -1)) + 1. / _far * t_vals.view(1, -1))
+        else:
+            z_vals_flat = _near * (1. - t_vals.view(1, -1)) + _far * t_vals.view(1, -1)
+
+        if z_vals_flat.shape[0] == 1 and rays_o.shape[0] > 1:
+            z_vals = z_vals_flat.expand(rays_o.shape[0], N_samples)
+        else: # Handles cases where near/far might be per-ray, or N_rays is 1
+             z_vals = z_vals_flat.reshape(rays_o.shape[0], N_samples) if z_vals_flat.numel() == N_rays * N_samples else z_vals_flat
+
+    if rand:
+        mids = .5 * (z_vals[..., 1:] + z_vals[..., :-1])
+        upper = torch.cat([mids, z_vals[..., -1:]], -1)
+        lower = torch.cat([z_vals[..., :1], mids], -1)
+        t_rand = torch.rand(z_vals.shape, device=rays_o.device)
+        z_vals = lower + (upper - lower) * t_rand
+
+    # Compute 3D query points: pts = o + t*d
+    # rays_o: [N_rays, 3] -> [N_rays, 1, 3]
+    # rays_d: [N_rays, 3] -> [N_rays, 1, 3]
+    # z_vals: [N_rays, N_samples] -> [N_rays, N_samples, 1]
+    # pts: [N_rays, N_samples, 3]
+    pts = rays_o[..., None, :] + rays_d[..., None, :] * z_vals[..., :, None]
+
+    # Query NeRF model
+    # pts.view(-1, 3) -> [N_rays * N_samples, 3]
+    embedded_pts = embed_fn_pts(pts.reshape(-1, 3)) # Shape: [N_rays*N_samples, input_ch_pts]
+
+    if use_viewdirs:
+        # Normalize view directions
+        viewdirs = rays_d / torch.norm(rays_d, dim=-1, keepdim=True) # [N_rays, 3]
+        # Expand viewdirs to match pts: [N_rays, N_samples, 3]
+        viewdirs_expanded = viewdirs[:, None, :].expand_as(pts)
+        # Embed view directions
+        embedded_views = embed_fn_views(viewdirs_expanded.reshape(-1, 3)) # Shape: [N_rays*N_samples, input_ch_views]
+        raw_output = nerf_model(embedded_pts, embedded_views)
+    else:
+        raw_output = nerf_model(embedded_pts)
+
+    # Reshape raw_output to [N_rays, N_samples, 4] (3 for RGB, 1 for sigma)
+    raw_output = raw_output.view(N_rays, N_samples, raw_output.shape[-1])
+
+    # Extract RGB and sigma, apply activations
+    rgb = torch.sigmoid(raw_output[..., :3])  # [N_rays, N_samples, 3]
+    # sigma_a is density. ReLU ensures it's non-negative.
+    sigma_a = F.relu(raw_output[..., 3])  # [N_rays, N_samples]
+    raw_sigma_for_return = raw_output[...,3] # For inspection
+
+    # Compute alpha values (volumetric rendering equation)
+    # dists: [N_rays, N_samples]
+    dists = z_vals[..., 1:] - z_vals[..., :-1] # Distances between adjacent samples
+    # Last segment: distance from last sample to infinity (or a very large number)
+    # This is to account for any density beyond the last sample.
+    # A large distance means that if there's any density, it will fully occlude.
+    dists = torch.cat([dists, torch.full_like(dists[..., :1], 1e10, device=rays_o.device)], -1)
+
+    # alpha = 1 - exp(-sigma * delta)
+    alpha = 1. - torch.exp(-sigma_a * dists)  # [N_rays, N_samples]
+
+    # Compute weights (transmittance * alpha)
+    # T_i = product_{j=1 to i-1} (1 - alpha_j)
+    # weights_i = T_i * alpha_i
+    # Transmittance T is the probability that the ray travels from near plane to sample i without being absorbed.
+    # We use 1e-10 to avoid numerical instability (e.g. T becoming exactly 0 then log(T) is -inf).
+    T = torch.cumprod(torch.cat([
+        torch.ones((N_rays, 1), device=rays_o.device), # T_1 = 1 (ray has not hit anything yet)
+        1. - alpha + 1e-10 # (1 - alpha_j) for j=1 to N_samples-1
+    ], -1), -1)[:, :-1] # Exclude last element, T should have N_samples elements.
+                        # Resulting T is [N_rays, N_samples]
+
+    weights = alpha * T  # [N_rays, N_samples]
+
+    # Compute accumulated maps
+    # C(r) = sum_{i=1 to N} w_i * c_i
+    rgb_map = torch.sum(weights[..., None] * rgb, dim=-2)  # [N_rays, 3]
+
+    # D(r) = sum_{i=1 to N} w_i * z_i
+    depth_map = torch.sum(weights * z_vals, dim=-1) # [N_rays]
+
+    # Accumulation map (total transmittance along the ray, or 1 - opacity)
+    # acc_map = sum w_i. If all weights are small, acc_map is small (transparent).
+    # If some weights are large, acc_map approaches 1 (opaque).
+    acc_map = torch.sum(weights, dim=-1) # [N_rays]
+
+    # Disparity map = 1 / depth_map (or more stable version)
+    # Max is to prevent division by zero if depth_map is zero (e.g. if acc_map is zero)
+    disp_map = 1. / torch.max(1e-10 * torch.ones_like(depth_map), depth_map / (acc_map + 1e-10))
+    disp_map = torch.nan_to_num(disp_map, nan=0.0) # Handle cases where acc_map is 0, depth_map is 0 -> nan
+
+    if white_bkgd:
+        # Composite onto a white background
+        # rgb_map = C_ray + (1 - acc_map) * white_color (which is 1.0)
+        rgb_map = rgb_map + (1. - acc_map[..., None])
+
+    return {
+        'rgb_map': rgb_map,
+        'depth_map': depth_map,
+        'disp_map': disp_map,
+        'acc_map': acc_map,
+        'weights': weights, # [N_rays, N_samples]
+        'z_vals': z_vals,   # [N_rays, N_samples]
+        'alpha': alpha,     # [N_rays, N_samples]
+        'raw_sigma': raw_sigma_for_return # [N_rays, N_samples] for debugging/loss
+    }


### PR DESCRIPTION
This commit includes the initial implementation of a PyTorch-based Neural Radiance Fields (NeRF) project.

Key changes and accomplishments so far:

1.  **Project Structure**:
    *   Set up the basic directory layout for data, source code (`src`), scripts, and results.
    *   Created `requirements.txt` with initial dependencies.

2.  **Data Loading (`src/datasets/blender.py`)**:
    *   Implemented `BlenderDataset` to load images, camera poses, and focal length from the Blender dataset format (`transforms.json`).
    *   Includes logic for generating rays (origins and directions) from camera parameters.
    *   Handles RGBA images by blending onto a specified background color (white or black) during data loading.

3.  **NeRF Model (`src/models/nerf.py`)**:
    *   Implemented `PositionalEncoder` for mapping input coordinates (3D points, viewing directions) to a higher-dimensional space.
    *   Implemented the main `NeRF` MLP model, supporting configurable depth, width, skip connections, and optional use of view directions. It can serve as both the coarse and fine model.
    *   Implemented `render_rays` function for the core volume rendering process. This includes:
        *   Sampling points along rays (linear or disparity-based, with stratified sampling).
        *   Querying the NeRF model for color and density.
        *   Computing accumulated transmittance and color via numerical quadrature.
        *   Returning RGB maps, depth maps, and other relevant data.
        *   Modified to accept `z_vals_override` for hierarchical sampling.
    *   Implemented `sample_pdf` for hierarchical sampling, which refines sampling locations based on the output of a coarse model.

4.  **Training Script (`scripts/train_nerf.py`)**:
    *   Developed a comprehensive training script with command-line argument parsing using `configargparse`.
    *   Initializes datasets (`BlenderDataset`) and DataLoaders for training.
    *   Initializes NeRF models (coarse and optionally a fine model for hierarchical sampling), positional encoders, and the Adam optimizer.
    *   Implemented the main training loop:
        *   Manual learning rate decay based on global step count.
        *   Coarse model rendering pass.
        *   If hierarchical sampling is enabled:
            *   Uses weights from the coarse pass to sample additional points via `sample_pdf`.
            *   Combines coarse and fine samples.
            *   Fine model rendering pass using the combined samples.
        *   Calculates Mean Squared Error (MSE) loss (coarse loss + fine loss if applicable).
        *   Performs backpropagation and optimizer updates.
        *   Logs training metrics (total loss, coarse/fine loss, coarse/fine PSNR, learning rate) to TensorBoard and the console (using `tqdm`).
    *   Implemented checkpoint saving (periodically and at the end of training) and loading for resuming training. Checkpoints include model states, optimizer state, epoch, global step, and arguments.

The project is now set up to train a NeRF model on the Blender dataset. The next planned step was to develop the evaluation script.